### PR TITLE
[BRANDING UPDATE] Update specified-versionprefix of https://github.com/maestro-auth-test/maestro-test1

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,9 +2,9 @@
 <Project>
   <PropertyGroup>
     <!-- This repo version -->
-    <VersionPrefix>5.0.0</VersionPrefix>
-    <PreReleaseVersionLabel>delta</PreReleaseVersionLabel>
-    <PreReleaseVersionIteration>17</PreReleaseVersionIteration>
+    <VersionPrefix>5.potato.bannana</VersionPrefix>
+    <PreReleaseVersionLabel>gamma</PreReleaseVersionLabel>
+    <PreReleaseVersionIteration>2</PreReleaseVersionIteration>
     <!-- Opt-out repo features -->
     <UsingToolXliff>false</UsingToolXliff>
     <UsingToolNetFrameworkReferenceAssemblies Condition="'$(DotNetBuildFromSource)' != 'true'">true</UsingToolNetFrameworkReferenceAssemblies>


### PR DESCRIPTION
This is an automated branding update PR
Branding changes:
Updates VersionPrefix from 5.0.0 to 5.potato.bannana
Updates PreReleaseVersionLabel from delta to gamma
Updates PreReleaseVersionIteration from 17 to 2
